### PR TITLE
VCST-4203: Remove obsolete code

### DIFF
--- a/src/VirtoCommerce.BulkActionsModule.Core/VirtoCommerce.BulkActionsModule.Core.csproj
+++ b/src/VirtoCommerce.BulkActionsModule.Core/VirtoCommerce.BulkActionsModule.Core.csproj
@@ -4,7 +4,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>True</IsPackable>
     <noWarn>1591</noWarn>
-    <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
@@ -19,6 +18,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.916.0-alpha.13164-vcst-4203-cleanup" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.917.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.BulkActionsModule.Core/VirtoCommerce.BulkActionsModule.Core.csproj
+++ b/src/VirtoCommerce.BulkActionsModule.Core/VirtoCommerce.BulkActionsModule.Core.csproj
@@ -19,6 +19,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.853.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.916.0-alpha.13164-vcst-4203-cleanup" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.BulkActionsModule.Data/VirtoCommerce.BulkActionsModule.Data.csproj
+++ b/src/VirtoCommerce.BulkActionsModule.Data/VirtoCommerce.BulkActionsModule.Data.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.853.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.916.0-alpha.13164-vcst-4203-cleanup" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.BulkActionsModule.Core\VirtoCommerce.BulkActionsModule.Core.csproj" />

--- a/src/VirtoCommerce.BulkActionsModule.Data/VirtoCommerce.BulkActionsModule.Data.csproj
+++ b/src/VirtoCommerce.BulkActionsModule.Data/VirtoCommerce.BulkActionsModule.Data.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <noWarn>1591</noWarn>
-    <LangVersion>latest</LangVersion>
     <IsPackable>True</IsPackable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -15,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.916.0-alpha.13164-vcst-4203-cleanup" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.917.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.BulkActionsModule.Core\VirtoCommerce.BulkActionsModule.Core.csproj" />

--- a/src/VirtoCommerce.BulkActionsModule.Web/VirtoCommerce.BulkActionsModule.Web.csproj
+++ b/src/VirtoCommerce.BulkActionsModule.Web/VirtoCommerce.BulkActionsModule.Web.csproj
@@ -4,7 +4,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <noWarn>1591</noWarn>
     <IsPackable>False</IsPackable>
-    <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
@@ -23,7 +22,7 @@
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.916.0-alpha.13164-vcst-4203-cleanup" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.917.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.BulkActionsModule.Core\VirtoCommerce.BulkActionsModule.Core.csproj" />

--- a/src/VirtoCommerce.BulkActionsModule.Web/VirtoCommerce.BulkActionsModule.Web.csproj
+++ b/src/VirtoCommerce.BulkActionsModule.Web/VirtoCommerce.BulkActionsModule.Web.csproj
@@ -23,7 +23,7 @@
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.853.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.916.0-alpha.13164-vcst-4203-cleanup" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.BulkActionsModule.Core\VirtoCommerce.BulkActionsModule.Core.csproj" />

--- a/src/VirtoCommerce.BulkActionsModule.Web/module.manifest
+++ b/src/VirtoCommerce.BulkActionsModule.Web/module.manifest
@@ -3,9 +3,9 @@
   <id>VirtoCommerce.BulkActionsModule</id>
   <version>3.805.0</version>
   <version-tag />
-  <platformVersion>3.916.0-alpha.13164-vcst-4203-cleanup</platformVersion>
+  <platformVersion>3.917.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Core" version="3.823.0-alpha.1666-vcst-4203-cleanup" />
+    <dependency id="VirtoCommerce.Core" version="3.824.0" />
   </dependencies>
   <title>Bulk Actions</title>
   <description>Bulk actions module</description>

--- a/src/VirtoCommerce.BulkActionsModule.Web/module.manifest
+++ b/src/VirtoCommerce.BulkActionsModule.Web/module.manifest
@@ -3,9 +3,9 @@
   <id>VirtoCommerce.BulkActionsModule</id>
   <version>3.805.0</version>
   <version-tag />
-  <platformVersion>3.853.0</platformVersion>
+  <platformVersion>3.916.0-alpha.13164-vcst-4203-cleanup</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Core" version="3.808.0" />
+    <dependency id="VirtoCommerce.Core" version="3.823.0-alpha.1666-vcst-4203-cleanup" />
   </dependencies>
   <title>Bulk Actions</title>
   <description>Bulk actions module</description>

--- a/tests/VirtoCommerce.BulkActionsModule.Tests/VirtoCommerce.BulkActionsModule.Tests.csproj
+++ b/tests/VirtoCommerce.BulkActionsModule.Tests/VirtoCommerce.BulkActionsModule.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <noWarn>1591</noWarn>
-    <LangVersion>latest</LangVersion>
+    
     <IsPackable>False</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description

## References
### QA-test:
### Required modules list URL:
https://github.com/VirtoCommerce/vc-modules/raw/refs/heads/VCST-4203-cleanup/update/modules.json
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4203
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.BulkActionsModule_3.805.0-pr-36-1266.zip